### PR TITLE
Rename :path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ plug Plug.Session,
   encryption_salt: "654321",    #
   ttl: 360,                     # use redis EXPIRE secs
   serializer: CustomSerializer, # Optional, defaults to `PlugSessionRedis.BinaryEncoder`
-  path: &MyPath.path/1          # Optional, defaults to passing the session ID through unmodified
+  db_path: &MyPath.path/1       # Optional, defaults to passing the session ID through unmodified
 ```
 
 ## Custom Serializers
@@ -46,7 +46,7 @@ An example serializer is shown in `lib/plug_session_redis/binary_encoder.ex`. Fo
 
 ## Storing data in another key
 
-The `:path` option above when configuring the plug lets you define a function which will take in the session ID binary string and returns a new storage location. If you'd like, for example, to store all sessions under the key `"myapp:sessions:" <> id` then an example implementation of the above configured `MyPath.path/1` would look like this:
+The `:db_path` option above when configuring the plug lets you define a function which will take in the session ID binary string and returns a new storage location. If you'd like, for example, to store all sessions under the key `"myapp:sessions:" <> id` then an example implementation of the above configured `MyPath.path/1` would look like this:
 
 ```elixir
 defmodule MyPath do

--- a/lib/plug_session_redis/store.ex
+++ b/lib/plug_session_redis/store.ex
@@ -5,22 +5,22 @@ defmodule PlugSessionRedis.Store do
   ```
   plug Plug.Session,
     store: PlugSessionRedis.Store,
-    key: "_my_app_key",           # Cookie name where the id is stored
-    table: :redis_sessions,       # Name of poolboy queue, make up anything
-    signing_salt: "123456",       # Keep this private
-    encryption_salt: "654321",    # Keep this private
-    ttl: 360,                     # Optional, defaults to :infinity
-    serializer: CustomSerializer, # Optional, defaults to `PlugSessionRedis.BinaryEncoder`
-    path: &MyPath.path_for_sid/1  # Optional, defaults to the passed in session id only
+    key: "_my_app_key",              # Cookie name where the id is stored
+    table: :redis_sessions,          # Name of poolboy queue, make up anything
+    signing_salt: "123456",          # Keep this private
+    encryption_salt: "654321",       # Keep this private
+    ttl: 360,                        # Optional, defaults to :infinity
+    serializer: CustomSerializer,    # Optional, defaults to `PlugSessionRedis.BinaryEncoder`
+    db_path: &MyPath.path_for_sid/1  # Optional, defaults to the passed in session id only
   ```
 
   Custom Serializers can work to provide a way to encode and decode the data stored in Redis if you're integrating
   with a legacy system. You provide the module name that implements `encode/1`, `encode!/1`, `decode/1`, and `decode!/1`
   which is called by `Plug` when fetching and storing the session state back.
 
-  Path dictates under what key within redis to store the key. You will be passed a single session ID binary and expected
+  DB path dictates under what key within redis to store the key. You will be passed a single session ID binary and expected
   to return another binary indicating where the key should be stored/fetched from. This allows you to store data under
-  a nested key so that other data can be stored within the same database. (i.e. key can become "sessions:" <> id instead)
+  a nested key so that other data can be stored within the same database. (i.e. key can become `"sessions:" <> id` instead)
   """
   alias PlugSessionRedis.BinaryEncoder
   @behaviour Plug.Session.Store
@@ -30,7 +30,7 @@ defmodule PlugSessionRedis.Store do
       Keyword.fetch!(opts, :table),
       Keyword.get(opts, :ttl, :infinite),
       Keyword.get(opts, :serializer, BinaryEncoder),
-      Keyword.get(opts, :path, &__MODULE__.path/1)
+      Keyword.get(opts, :db_path, &__MODULE__.path/1)
     }
   end
 


### PR DESCRIPTION
Plug is already using it and it drops that key before handing it off to us, shown here: https://github.com/elixir-lang/plug/blob/master/lib/plug/session.ex#L48

Sorry for this issue!